### PR TITLE
remove highlight link to Normal

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -414,7 +414,6 @@ if v:version >= 508 || !exists('did_python_syn_inits')
 
   HiLink pythonDecorator        Define
   HiLink pythonDottedName       Function
-  HiLink pythonDot              Normal
 
   HiLink pythonComment          Comment
   if !s:Enabled('g:python_highlight_file_headers_as_comments')


### PR DESCRIPTION
linking to Normal breaks CursorLine highlighting for example:
hi Normal guifg=#ffffff guibg=#000000
hi CursorLine guibg=#111111